### PR TITLE
Update A02_2021-Cryptographic_Failures.ja.md

### DIFF
--- a/2021/docs/A02_2021-Cryptographic_Failures.ja.md
+++ b/2021/docs/A02_2021-Cryptographic_Failures.ja.md
@@ -1,3 +1,148 @@
+# A02:2021 – 暗号化の失敗
+
+## 因子
+
+| CWEs Mapped | Max Incidence Rate | Avg Incidence Rate | Max Coverage | Avg Coverage | Avg Weighted Exploit | Avg Weighted Impact | Total Occurrences | Total CVEs |
+|:-------------:|:--------------------:|:--------------------:|:--------------:|:--------------:|:----------------------:|:---------------------:|:-------------------:|:------------:|
+| 29          | 46.44%             | 4.49%              | 79.33%       | 34.85%       | 7.29                 | 6.81                | 233,788           | 3,075      |
+
+## 概要
+
+前回から順位を一つ上げたこのカテゴリは、以前は*機微な情報の露出*として知られていたものです。
+このカテゴリは根本的な要因よりも、暗号化技術の不適切な使用、または暗号化の欠如に関連した幅広い障害に焦点を当てています。こうした障害は、時に機微な情報の露出を結果としてもたらします。
+考慮すべきCWEには、*CWE-259:ハードコードされたパスワードの使用*、*CWE-327:不適切な暗号化アルゴリズム*、*CWE-331:不十分なエントロピー*があります。
+
+## 解説
+
+まず、送信あるいは保存するデータが保護を必要とするか見極めます。例えば、パスワード、クレジットカード番号、健康記録、個人データやビジネス上の機密は特別な保護が必要になります。データに対して、EUの一般データ保護規則(GDPR)のようなプライバシー関連の法律が適用される場合、また、PCIデータセキュリティスタンダード(PCI DSS)など金融の情報保護の要求があるような規定がある場合には、特に注意が必要です。そのようなデータすべてについて、以下を確認してください:
+
+-   どんなデータであれ平文で送信していないか。これは、HTTP、SMTP、FTPのようなプロトコルを使っている場合に該当する。外部インターネットへのトラフィックは危険である。また、ロードバランサ、ウェブサーバ、バックエンドシステムなどの内部の通信もすべて確認すること。
+
+-   古いまたは脆弱な暗号アルゴリズムを初期設定のまま、または古いコードで使っていないか。
+
+-   初期値のままの暗号鍵の使用、弱い暗号鍵を生成または再利用、適切な暗号鍵管理または鍵のローテーションをしていない、これらの該当する箇所はないか。
+
+-   ユーザエージェント（ブラウザ）のセキュリティに関するディレクティブやヘッダーが欠落しているなど、暗号化が強制されていない箇所はないか。
+
+-   アプリ、メールクライアントなどのユーザエージェントが受信したサーバ証明書が正当なものか検証していない箇所はないか。
+
+ASVS Crypto (V7)、Data Protection (V9)、および SSL/TLS (V10) を参照。
+
+## 防止方法
+
+最低限実施すべきことを以下に挙げます。そして、参考資料を検討してください:
+
+-   アプリケーションごとに処理するデータ、保存するデータ、送信するデータを分類する。そして、どのデータがプライバシー関連の法律・規則の要件に該当するか、またどのデータがビジネス上必要なデータか判定する。
+
+-   前述の分類をもとにアクセス制御を実装する。
+
+-   必要のない機微な情報を保存しない。できる限りすぐにそのような機微な情報を破棄するか、PCI DSSに準拠したトークナイゼーションまたはトランケーションを行う。データが残っていなければ盗まれない。
+
+-   保存時にすべての機微な情報を暗号化しているか確認する。
+
+-   最新の暗号強度の高い標準アルゴリズム、プロトコル、暗号鍵を実装しているか確認する。そして適切に暗号鍵を管理する。
+
+-   前方秘匿性(PFS)を有効にしたTLS、サーバサイドによる暗号スイートの優先度決定、セキュアパラメータなどのセキュアなプロトコルで、通信経路上のすべてのデータを暗号化する。HTTP Strict Transport Security (HSTS)のようなディレクティブで暗号化を強制する。
+
+-   機微な情報を含むレスポンスのキャッシングを無効にする。
+
+-   パスワードを保存する際、Argon2、scrypt、bcrypt、PBKDF2のようなワークファクタ(遅延ファクタ)のある、強くかつ適応可能なレベルのソルト付きハッシュ関数を用いる。
+
+-   設定とその設定値がそれぞれ独立して効果があるか検証する。
+
+## 攻撃シナリオの例
+
+**シナリオ #1**: あるアプリケーションは、データベースの自動暗号化を使用し、クレジットカード番号を暗号化します。しかし、そのデータが取得されるときに自動的に復号されるため、SQLインジェクションによって平文のクレジットカード番号を取得できてしまいます。
+
+**シナリオ #2**: あるサイトは、すべてのページでTLSを使っておらず、ユーザにTLSを強制していません。また、そのサイトでは弱い暗号アルゴリズムをサポートしています。攻撃者はネットワークトラフィックを監視し（例えば、暗号化していない無線ネットワークで）、HTTPS通信をHTTP通信にダウングレードしそのリクエストを盗聴することで、ユーザのセッションクッキーを盗みます。そして、攻撃者はこのクッキーを再送しユーザの(認証された)セッションを乗っ取り、そのユーザの個人データを閲覧および改ざんできます。また、攻撃者はセッションを乗っ取る代わりに、すべての送信データ（例えば、入金の受取人）を改ざんできます。
+
+**シナリオ #3**: あるパスワードデータベースは、ソルトなしのハッシュまたは単純なハッシュでパスワードを保存しています。もしファイルアップロードの欠陥があれば、攻撃者はそれを悪用してパスワードデータベースを取得できます。事前に計算されたハッシュのレインボーテーブルで、すべてのソルトなしのハッシュが解読されてしまいます。そして、たとえソルトありでハッシュ化されていても、単純または高速なハッシュ関数で生成したハッシュはGPUで解読されてしまうかもしれません。
+
+## 参考資料
+
+-   [OWASP Proactive Controls: Protect Data
+    Everywhere](https://owasp.org/www-project-proactive-controls/v3/en/c8-protect-data-everywhere)
+
+-   [OWASP Application Security Verification Standard (V7,
+    9, 10)](https://owasp.org/www-project-application-security-verification-standard)
+
+-   [OWASP Cheat Sheet: Transport Layer
+    Protection](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html)
+
+-   [OWASP Cheat Sheet: User Privacy
+    Protection](https://cheatsheetseries.owasp.org/cheatsheets/User_Privacy_Protection_Cheat_Sheet.html)
+
+-   OWASP Cheat Sheet: Password and Cryptographic Storage
+
+-   [OWASP Cheat Sheet:
+    HSTS](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html)
+
+-   OWASP Testing Guide: Testing for weak cryptography
+
+
+## 対応するCWE一覧
+
+CWE-261 Weak Encoding for Password
+
+CWE-296 Improper Following of a Certificate's Chain of Trust
+
+CWE-310 Cryptographic Issues
+
+CWE-319 Cleartext Transmission of Sensitive Information
+
+CWE-321 Use of Hard-coded Cryptographic Key
+
+CWE-322 Key Exchange without Entity Authentication
+
+CWE-323 Reusing a Nonce, Key Pair in Encryption
+
+CWE-324 Use of a Key Past its Expiration Date
+
+CWE-325 Missing Required Cryptographic Step
+
+CWE-326 Inadequate Encryption Strength
+
+CWE-327 Use of a Broken or Risky Cryptographic Algorithm
+
+CWE-328 Reversible One-Way Hash
+
+CWE-329 Not Using a Random IV with CBC Mode
+
+CWE-330 Use of Insufficiently Random Values
+
+CWE-331 Insufficient Entropy
+
+CWE-335 Incorrect Usage of Seeds in Pseudo-Random Number Generator
+(PRNG)
+
+CWE-336 Same Seed in Pseudo-Random Number Generator (PRNG)
+
+CWE-337 Predictable Seed in Pseudo-Random Number Generator (PRNG)
+
+CWE-338 Use of Cryptographically Weak Pseudo-Random Number Generator
+(PRNG)
+
+CWE-340 Generation of Predictable Numbers or Identifiers
+
+CWE-347 Improper Verification of Cryptographic Signature
+
+CWE-523 Unprotected Transport of Credentials
+
+CWE-720 OWASP Top Ten 2007 Category A9 - Insecure Communications
+
+CWE-757 Selection of Less-Secure Algorithm During Negotiation
+('Algorithm Downgrade')
+
+CWE-759 Use of a One-Way Hash without a Salt
+
+CWE-760 Use of a One-Way Hash with a Predictable Salt
+
+CWE-780 Use of RSA Algorithm without OAEP
+
+CWE-818 Insufficient Transport Layer Protection
+
+CWE-916 Use of Password Hash With Insufficient Computational Effort
+
 # A02:2021 – Cryptographic Failures
 
 ## Factors


### PR DESCRIPTION
[A02:2021 – Cryptographic Failures](https://github.com/owasp-ja/Top10/blob/master/2021/docs/A02_2021-Cryptographic_Failures.md) の日本語翻訳案です。

- タイトル、概要を新訳
    - タイトルは「暗号化の失敗」としていますが、より開いて「暗号化設定の不備、または暗号化の欠如」とした方が意図が伝わりやすいかもしれません。一旦は原文に近い形にしていますが、修正が必要であれば議論させてください。
- 解説、防止方法、攻撃シナリオの例はほぼ A3:2017 Sensitive Data Exposure と同じものだったので、[2017の翻訳](https://github.com/OWASP/Top10/blob/master/2017/ja/0xa3-sensitive-data-disclosure.md)をほぼそのまま使わせていただきました。ただし以下、変更があります。
    - 「解説」の冒頭、「〜ビジネス上の機密は特に保護する必要があります。」を「〜ビジネス上の機密は特別な保護が必要になります。」に変更。原文は ”〜business secrets require extra protection”
    - 「解説」の箇条書き1つ目で、「External internet traffic is especially dangerous.」が「External internet traffic is hazardous.」に微修正されていることを受けて、翻訳も「内部からインターネットに送信する場合、特に危険である。」→「外部インターネットへのトラフィックは危険である。」に調整
    - 「防止方法」に「機微な情報を含むレスポンスのキャッシングを無効にする。」を追加
        - A03:2017 の翻訳にはこの行が欠如していたので、上記翻訳で問題なければ、別途A03:2017の方にも PR を出します
- 参考資料、対応するCWE一覧は原文まま